### PR TITLE
Fixed parallaxing performance issues on Chrome by changing .logo to p…

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -61,8 +61,7 @@ html, body {
 }
 
 .logo {
-  position: relative;
-  top: 0%;
+  position: fixed;
   width: 100vw;
   height: 100vh;
   display: -webkit-box;

--- a/docs/js/index.js
+++ b/docs/js/index.js
@@ -8,7 +8,7 @@ function parallax() {
     $.css("footer", "display", "block");
   } else {
     $.css(".logo", {
-      top: $.scrollTop() / 1.5 + "px",
+      transform: "translateY( -" + $.scrollTop() / 2.5 + "px)",
       display: ""
     });
     $.css("footer", "display", "none");


### PR DESCRIPTION
The logo parallax at the top of the docs page was really choppy on Chrome. 
After some investigation I found that it was caused by `.logo` being assigned `position:relative` rather than `position:fixed`.

I changed that property, as well as the `top` property being animated in `index.js` to `transform:translateY()` as this is a bit lighter weight on the browser.